### PR TITLE
Hotfix for techsplitaverage implementation

### DIFF
--- a/temoa/temoa_model/hybrid_loader.py
+++ b/temoa/temoa_model/hybrid_loader.py
@@ -600,22 +600,6 @@ class HybridLoader:
             ).fetchall()
         load_element(M.TechInputSplit, raw, self.viable_rt, (0, 3))
 
-        # TechInputSplitAverage
-        if self.table_exists('TechInputSplitAverage'):
-            if mi:
-                raw = cur.execute(
-                    'SELECT region, period, input_comm, tech, min_proportion '
-                    'FROM main.TechInputSplitAverage '
-                    'WHERE period >= ? AND period <= ?',
-                    (mi.base_year, mi.last_demand_year),
-                ).fetchall()
-            else:
-                raw = cur.execute(
-                    'SELECT region, period, input_comm, tech, min_proportion '
-                    'FROM main.TechInputSplitAverage '
-                ).fetchall()
-            load_element(M.TechInputSplitAverage, raw, self.viable_rt, (0, 3))
-
         # TechOutputSplit
         if self.table_exists('TechOutputSplit'):
             if mi:

--- a/temoa/temoa_model/temoa_initialize.py
+++ b/temoa/temoa_model/temoa_initialize.py
@@ -685,13 +685,6 @@ def CreateSparseDicts(M: 'TemoaModel'):
                 t,
             ) not in M.inputsplitVintages:
                 M.inputsplitVintages[r, p, i, t] = set()
-            if (r, p, i, t) in M.TechInputSplitAverage.sparse_iterkeys() and (
-                r,
-                p,
-                i,
-                t,
-            ) not in M.inputsplitaverageVintages:
-                M.inputsplitaverageVintages[r, p, i, t] = set()
             if (r, p, t, o) in M.TechOutputSplit.sparse_iterkeys() and (
                 r,
                 p,
@@ -734,8 +727,6 @@ def CreateSparseDicts(M: 'TemoaModel'):
                 M.rampVintages[r, p, t].add(v)
             if (r, p, i, t) in M.TechInputSplit.sparse_iterkeys():
                 M.inputsplitVintages[r, p, i, t].add(v)
-            if (r, p, i, t) in M.TechInputSplitAverage.sparse_iterkeys():
-                M.inputsplitaverageVintages[r, p, i, t].add(v)
             if (r, p, t, o) in M.TechOutputSplit.sparse_iterkeys():
                 M.outputsplitVintages[r, p, t, o].add(v)
             if t in M.tech_resource:
@@ -1323,9 +1314,9 @@ def TechInputSplitAnnualConstraintIndices(M: 'TemoaModel'):
 def TechInputSplitAverageConstraintIndices(M: 'TemoaModel'):
     indices = set(
         (r, p, i, t, v)
-        for r, p, i, t in M.inputsplitaverageVintages.keys()
-        if t in M.tech_variable
-        for v in M.inputsplitaverageVintages[r, p, i, t]
+        for r, p, i, t in M.inputsplitVintages.keys()
+        if t in M.tech_variable and t not in M.tech_annual
+        for v in M.inputsplitVintages[r, p, i, t]
     )
     return indices
 
@@ -1334,7 +1325,7 @@ def TechOutputSplitConstraintIndices(M: 'TemoaModel'):
     indices = set(
         (r, p, s, d, t, v, o)
         for r, p, t, o in M.outputsplitVintages.keys()
-        if t not in M.tech_annual
+        if t not in M.tech_annual and t not in M.tech_variable
         for v in M.outputsplitVintages[r, p, t, o]
         for s in M.time_season
         for d in M.time_of_day
@@ -1347,12 +1338,21 @@ def TechOutputSplitAnnualConstraintIndices(M: 'TemoaModel'):
     indices = set(
         (r, p, t, v, o)
         for r, p, t, o in M.outputsplitVintages.keys()
-        if t in M.tech_annual and t not in M.tech_variable
+        if t in M.tech_annual
         for v in M.outputsplitVintages[r, p, t, o]
     )
 
     return indices
 
+def TechOutputSplitAverageConstraintIndices(M: 'TemoaModel'):
+    indices = set(
+        (r, p, t, v, o)
+        for r, p, t, o in M.outputsplitVintages.keys()
+        if t in M.tech_variable and t not in M.tech_annual
+        for v in M.outputsplitVintages[r, p, t, o]
+    )
+
+    return indices
 
 def get_loan_life(M, r, t, _):
     return M.LoanLifetimeTech[r, t]

--- a/temoa/temoa_model/temoa_model.py
+++ b/temoa/temoa_model/temoa_model.py
@@ -99,7 +99,6 @@ class TemoaModel(AbstractModel):
         M.storageVintages = dict()
         M.rampVintages = dict()
         M.inputsplitVintages = dict()
-        M.inputsplitaverageVintages = dict()
         M.outputsplitVintages = dict()
         M.ProcessByPeriodAndOutput = dict()
         M.exportRegions = dict()
@@ -287,9 +286,6 @@ class TemoaModel(AbstractModel):
         M.LoanLifetimeProcess = Param(M.LoanLifetimeProcess_rtv, default=get_loan_life)
 
         M.TechInputSplit = Param(M.regions, M.time_optimize, M.commodity_physical, M.tech_all)
-        M.TechInputSplitAverage = Param(
-            M.regions, M.time_optimize, M.commodity_physical, M.tech_variable
-        )
         M.TechOutputSplit = Param(M.regions, M.time_optimize, M.tech_all, M.commodity_carrier)
 
         M.RenewablePortfolioStandardConstraint_rpg = Set(
@@ -805,6 +801,13 @@ class TemoaModel(AbstractModel):
         )
         M.TechOutputSplitAnnualConstraint = Constraint(
             M.TechOutputSplitAnnualConstraint_rptvo, rule=TechOutputSplitAnnual_Constraint
+        )
+
+        M.TechOutputSplitAverageConstraint_rptvo = Set(
+            dimen=5, initialize=TechOutputSplitAverageConstraintIndices
+        )
+        M.TechOutputSplitAverageConstraint = Constraint(
+            M.TechOutputSplitAverageConstraint_rptvo, rule=TechOutputSplitAverage_Constraint
         )
 
         M.RenewablePortfolioStandardConstraint = Constraint(

--- a/temoa/temoa_model/temoa_rules.py
+++ b/temoa/temoa_model/temoa_rules.py
@@ -2999,7 +2999,7 @@ def TechInputSplitAverage_Constraint(M: 'TemoaModel', r, p, i, t, v):
         for S_o in M.ProcessOutputsByInput[r, p, t, v, i]
     )
 
-    expr = inp >= M.TechInputSplitAverage[r, p, i, t] * total_inp
+    expr = inp >= M.TechInputSplit[r, p, i, t] * total_inp
     return expr
 
 
@@ -3076,6 +3076,40 @@ def TechOutputSplitAnnual_Constraint(M: 'TemoaModel', r, p, t, v, o):
         M.V_FlowOutAnnual[r, p, S_i, t, v, S_o]
         for S_i in M.processInputs[r, p, t, v]
         for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+    )
+
+    expr = out >= M.TechOutputSplit[r, p, t, o] * total_out
+    return expr
+
+def TechOutputSplitAverage_Constraint(M: 'TemoaModel', r, p, t, v, o):
+    r"""
+    This constraint operates similarly to TechOutputSplit_Constraint.
+    However, under this function, only the technologies with constant annual
+    output (i.e., members of the :math:`tech_annual` set) are considered.
+
+    .. math::
+       :label: TechOutputSplitAnnual
+
+         \sum_{I, T^{a}} \textbf{FOA}_{r, p, i, t \in T^{a}, v, o}
+
+       \geq
+
+         TOS_{r, p, t, o} \cdot \sum_{I, O, T^{a}} \textbf{FOA}_{r, p, s, d, i, t \in T^{a}, v, o}
+
+       \forall \{r, p, t \in T^{a}, v, o\} \in \Theta_{\text{TechOutputSplitAnnual}}"""
+    out = sum(
+        M.V_FlowOut[r, p, S_s, S_d, S_i, t, v, o]
+        for S_i in M.ProcessInputsByOutput[r, p, t, v, o]
+        for S_s in M.time_season
+        for S_d in M.time_of_day
+    )
+
+    total_out = sum(
+        M.V_FlowOut[r, p, S_s, S_d, S_i, t, v, S_o]
+        for S_i in M.processInputs[r, p, t, v]
+        for S_o in M.ProcessOutputsByInput[r, p, t, v, S_i]
+        for S_s in M.time_season
+        for S_d in M.time_of_day
     )
 
     expr = out >= M.TechOutputSplit[r, p, t, o] * total_out


### PR DESCRIPTION
TechSplitAverage tables now do nothing. Annual split constraint is used if tech is tagged as annual. Average split constraint is used if tech is tagged as variable but NOT annual. If neither tag is used then the regular techsplit constraint is used.

![image](https://github.com/user-attachments/assets/f49671b5-5ff1-4d92-bf5c-2c0b04b6b222)
































































































































































