### PR TITLE
Feature/evolving myopic

### DIFF
--- a/data_files/my_configs/config_sample.toml
+++ b/data_files/my_configs/config_sample.toml
@@ -132,6 +132,12 @@ weighting = "hull_expansion"  # use a convex hull expansion algorithm to weight 
 [myopic]
 view_depth = 2   # number of periods seen/analyzed per iteration
 step_size = 1    # number of periods to step by (must be <= view depth)
+# Evolution mode: if true, the view depth shortens closer to the end of the horizon and
+# the evolution script is called between iterations. If false, there is no need to 
+# shorten the view depth near end of horizon as the following decisions will be the 
+# same as the final full-depth iteration.
+evolving = false
+evolution_script = "temoa\\extensions\\myopic\\evolution_updater.py"
 
 [morris]
 perturbation = 0.10     # amount to perturb marked parameters (ex:  0.10 -> +/- 10%)

--- a/temoa/extensions/myopic/evolution_updater.py
+++ b/temoa/extensions/myopic/evolution_updater.py
@@ -1,0 +1,30 @@
+import sqlite3
+from temoa.extensions.myopic.myopic_index import MyopicIndex
+
+def iterate(
+        idx: MyopicIndex | None = None,
+        prev_base_year: int | None = None,
+        last_instance_status: str | None = None,
+        db_con: sqlite3.Connection | None = None,
+    ):
+    """
+    This function is called at the end of each myopic iteration,
+    after the results have been recorded to the myopic database. 
+    You can use it to update your myopic database with any additional
+    information you want to track across iterations, or to implement
+    an evolving myopic approach where the model structure changes
+    across iterations based on some user-defined logic.
+    
+        Parameters:
+        - idx (MyopicIndex): The index object for the current iteration,
+            containing information about the base year, view depth, etc.
+        - prev_base_year (int): The base year of the previous iteration.
+        - last_instance_status (str): The status of the last solved instance
+            (e.g., 'optimal', 'roll_back', etc.)
+        - db_con (sqlite3.Connection): A connection object to the myopic database,
+            which you can use to read/write data as needed.
+    """
+
+    # Update your myopic database here.
+
+    return

--- a/temoa/extensions/myopic/myopic_sequencer.py
+++ b/temoa/extensions/myopic/myopic_sequencer.py
@@ -122,6 +122,8 @@ class MyopicSequencer:
                         f'is larger than the view depth ({self.view_depth}).  '
                         f'Check config'
                     )
+                self.evolving: bool = myopic_options.get('evolving')
+                self.evolution_script: str = myopic_options.get('evolution_script')
         else:
             # A None was passed for config and the caller is responsible for setting instance vars
             pass
@@ -473,17 +475,43 @@ class MyopicSequencer:
         # check that we have enough periods to do myopic run
         # 2 iterations, excluding end year, will be via shortened depth, if reqd.
         if len(future_periods) < self.view_depth+1:
-            logger.error(
-                'Not enough future years to run myopic mode. Need %d including end year. Got %d.', self.view_depth+1, len(future_periods)
-            )
-            sys.exit(-1)
+            msg = (
+                'Not enough future years to run myopic mode. Need {:d} including end year. Got {:d}.'
+            ).format(self.view_depth+1, len(future_periods))
+            logger.error(msg)
+            raise RuntimeError(msg)
         self.optimization_periods = future_periods.copy()
-        last_idx = len(future_periods) - 1
-        for idx in range(0, len(future_periods[:-1]), self.step_size):
-            depth = min(self.view_depth, last_idx - idx)
-            step = min(self.step_size, last_idx - idx)
+
+        last_base_year: int
+        if self.evolving:
+            # view window shrinks towards P_end
+            last_base_year = len(future_periods) - 2
+        else:
+            # shrinking view window is unnecessary as same decisions will be repeated
+            last_base_year = len(future_periods) - self.view_depth - 1
+
+        base_years = list(range(0, last_base_year, self.step_size))
+        base_years.append(last_base_year)
+
+        for n, idx in enumerate(base_years):
+            depth = min(self.view_depth, len(future_periods) - idx - 1)
+            if idx == base_years[-1]:
+                # last period, record the rest
+                step = depth
+            else:
+                # record to next base year
+                step = base_years[n+1] - idx
+            
             if depth < 1:
-                break
+                msg = (
+                    'Calculated MyopicIndex with non-positive depth.  This should never happen.  Check the logic.  '
+                    'idx: {}, step: {}, depth: {}, future_periods: {}'.format(
+                        idx, step, depth, future_periods
+                    )
+                )
+                logger.error(msg)
+                raise RuntimeError(msg)
+
             myopic_idx = MyopicIndex(
                 base_year=future_periods[idx],
                 step_year=future_periods[idx + step],

--- a/temoa/extensions/myopic/myopic_sequencer.py
+++ b/temoa/extensions/myopic/myopic_sequencer.py
@@ -225,6 +225,26 @@ class MyopicSequencer:
             # 4. update the MyopicEfficiency table so it is ready for the upcoming data pull.
             self.update_myopic_efficiency_table(myopic_index=idx, prev_base=last_base_year)
 
+            # call the evolution script and pass it the myopic index and last instance status, if evolving is selected
+            if self.evolving:
+                if not self.evolution_script:
+                    logger.info(
+                        'Evolving myopic mode selected, but no evolution script provided.'
+                    )
+                else:
+                    # import the script as a module and call the iterate function with the idx and last_instance_status
+                    import importlib.util
+
+                    spec = importlib.util.spec_from_file_location("evolution_script", self.evolution_script)
+                    evolution_module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(evolution_module)
+                    evolution_module.iterate(
+                        idx=idx,
+                        prev_base_year=last_base_year,
+                        last_instance_status=last_instance_status,
+                        db_con=self.output_con,  # pass the db connection so the script can make updates as needed
+                    )
+
             # 5. pull the data
             # make a data loader
             data_loader = HybridLoader(self.output_con, self.config)

--- a/temoa/extensions/myopic/myopic_sequencer.py
+++ b/temoa/extensions/myopic/myopic_sequencer.py
@@ -502,16 +502,13 @@ class MyopicSequencer:
             raise RuntimeError(msg)
         self.optimization_periods = future_periods.copy()
 
-        last_base_year: int
-        if self.evolving:
-            # view window shrinks towards P_end
-            last_base_year = len(future_periods) - 2
-        else:
-            # shrinking view window is unnecessary as same decisions will be repeated
-            last_base_year = len(future_periods) - self.view_depth - 1
-
-        base_years = list(range(0, last_base_year, self.step_size))
-        base_years.append(last_base_year)
+        last_base_year = ((len(future_periods) - 2) // self.step_size) * self.step_size
+        base_years = list(range(0, last_base_year+1, self.step_size))
+        if not self.evolving:
+            # Remove redundant iterations near end of horizon
+            catch_Pe = [i for i in base_years if i + self.view_depth >= len(future_periods) - 1]
+            if len(catch_Pe) > 1:
+                base_years = list(range(0, catch_Pe[0]+1, self.step_size))
 
         for n, idx in enumerate(base_years):
             depth = min(self.view_depth, len(future_periods) - idx - 1)

--- a/temoa/temoa_model/temoa_config.py
+++ b/temoa/temoa_model/temoa_config.py
@@ -210,6 +210,12 @@ class TemoaConfig:
             msg += '{:>{}s}: {}\n'.format(
                 'Myopic step size', width, self.myopic_inputs.get('step_size')
             )
+            msg += '{:>{}s}: {}\n'.format(
+                'Evolving', width, bool(self.myopic_inputs.get('evolving'))
+            )
+            msg += '{:>{}s}: {}\n'.format(
+                'Evolution script', width, str(self.myopic_inputs.get('evolution_script'))
+            )
 
         if self.scenario_mode == TemoaMode.MGA:
             msg += spacer

--- a/tests/test_myopic_sequencer.py
+++ b/tests/test_myopic_sequencer.py
@@ -33,12 +33,12 @@ from temoa.extensions.myopic.myopic_sequencer import MyopicSequencer
 params = [
     {
         'name': 'single_step',
-        'conf_data': {'step_size': 1, 'view_depth': 3},
+        'conf_data': {'step_size': 1, 'view_depth': 3, 'evolving': True, 'evolution_script': None},
         'expected_steps': 4,
     },  # 4 single steps
     {
         'name': 'triple_step',
-        'conf_data': {'step_size': 3, 'view_depth': 4},
+        'conf_data': {'step_size': 3, 'view_depth': 4, 'evolving': True, 'evolution_script': None},
         'expected_steps': 2,  # 1 step of 3, followed by 1 step of 1
     },
 ]
@@ -67,6 +67,8 @@ def test_characterize_run(param):
     ms = MyopicSequencer(config=None)
     ms.view_depth = param['conf_data']['view_depth']
     ms.step_size = param['conf_data']['step_size']
+    ms.evolving = param['conf_data']['evolving']
+    ms.evolution_script = param['conf_data']['evolution_script']
 
     ms.characterize_run(future_periods=list(range(5)))
     assert len(ms.instance_queue) == param['expected_steps'], (


### PR DESCRIPTION
Distinguishes between evolving and unevolving myopic.

## Evolving myopic:
We call an "evolution script" between iterations, which may be used to update the myopic database (e.g., to "surprise" the optimisation as it moves forward). In this mode, the problem may change going forward and so we need to "shrink" the view depth as we approach the end of the horizon, so that we make decisions at every defined step.

## Unevolving myopic:
We do not call the evolution script. As a result, the period which views to the end of the horizon should be the final planning period. There is no need to shrink the view depth and step forward as the model should make identical decisions, as this is just a subproblem of the previous problem.

NOTE: Evolving myopic (sans evolution script) is currently the default in Temoa, but I think unevolving should be default to save compute. This change makes unevolving the default behaviour.

## Examples with Utopia

## Evolving myopic:

#### View depth: 1, Step size: 1
<img width="461" height="325" alt="image" src="https://github.com/user-attachments/assets/f33321c8-52fa-4a1a-83b8-cb8ab152716b" />

#### View depth: 2, Step size: 1
<img width="460" height="322" alt="image" src="https://github.com/user-attachments/assets/683a8a69-25a6-461d-a9ee-cdd35c0079f6" />

#### View depth: 3, Step size: 1
<img width="460" height="327" alt="image" src="https://github.com/user-attachments/assets/223b5171-e208-4ebf-9f89-f070540f1c88" />

#### View depth: 2, Step size: 2
<img width="457" height="246" alt="image" src="https://github.com/user-attachments/assets/8e6f37c4-d6e2-43a5-a013-3d71989d2280" />

#### View depth: 3, Step size: 2
<img width="459" height="248" alt="image" src="https://github.com/user-attachments/assets/ec890753-24ca-44a5-bf0f-50b9fd72662e" />

#### View depth: 3, Step size: 3
<img width="463" height="174" alt="image" src="https://github.com/user-attachments/assets/492a7bcf-5eb4-4c77-be79-0f892cb8e40f" />

## Unevolving myopic:

#### View depth: 1, Step size: 1
<img width="461" height="327" alt="image" src="https://github.com/user-attachments/assets/5bafe900-d052-42d2-b589-0bdfce63a716" />

#### View depth: 2, Step size: 1
<img width="463" height="252" alt="image" src="https://github.com/user-attachments/assets/dfae2838-ec29-4ab7-9995-52d02b96410c" />

#### View depth: 3, Step size: 1
<img width="459" height="168" alt="image" src="https://github.com/user-attachments/assets/d8c623f4-2c26-4fb1-ad4c-b922b463976c" />

#### View depth: 2, Step size: 2
<img width="460" height="250" alt="image" src="https://github.com/user-attachments/assets/ac5c8dd6-d617-4804-8995-76f4060f71a0" />

#### View depth: 3, Step size: 2
<img width="460" height="170" alt="image" src="https://github.com/user-attachments/assets/c63cce84-e702-4709-b095-16d79d0cbedb" />

#### View depth: 3, Step size: 3
<img width="460" height="170" alt="image" src="https://github.com/user-attachments/assets/6a689f13-9d6e-4b79-8915-d3a3b7e26a51" />