### PR TITLE
Fix existing capacity logic in myopic

### DIFF
--- a/temoa/temoa_model/temoa_initialize.py
+++ b/temoa/temoa_model/temoa_initialize.py
@@ -377,8 +377,7 @@ def CheckExistingCapacity(M: 'TemoaModel'):
                 f"Existing capacity {r, t, v} with lifetime {life} and capacity {cap} should extend into "
                 "future periods but it not in process periods. Was it included in the Efficiency table?"
             )
-            logger.error(msg)
-            raise ValueError(msg)
+            logger.warning(msg)
 
 
 def CheckCapacityFactorProcess(M: 'TemoaModel'):

--- a/tests/testing_data/mediumville_sets.json
+++ b/tests/testing_data/mediumville_sets.json
@@ -3295,6 +3295,7 @@
     ],
     "LimitActivityShareConstraint_rpgg": [],
     "LimitAnnualCapacityFactorConstraint_rtvo": [],
+    "LimitAnnualCapacityFactorConstraint_rptvo": [],
     "LimitCapacityConstraint_rpt": [
         [
             "B",

--- a/tests/testing_data/test_system_sets.json
+++ b/tests/testing_data/test_system_sets.json
@@ -39964,6 +39964,7 @@
     ],
     "LimitActivityShareConstraint_rpgg": [],
     "LimitAnnualCapacityFactorConstraint_rtvo": [],
+    "LimitAnnualCapacityFactorConstraint_rptvo": [],
     "LimitCapacityConstraint_rpt": [],
     "LimitCapacityShareConstraint_rpgg": [],
     "LimitDegrowthCapacityConstraint_rpt": [],

--- a/tests/testing_data/utopia_sets.json
+++ b/tests/testing_data/utopia_sets.json
@@ -22214,6 +22214,7 @@
     "LimitActivityConstraint_rpt": [],
     "LimitActivityShareConstraint_rpgg": [],
     "LimitAnnualCapacityFactorConstraint_rtvo": [],
+    "LimitAnnualCapacityFactorConstraint_rptvo": [],
     "LimitCapacityConstraint_rpt": [
         [
             "utopia",


### PR DESCRIPTION
There are cases in myopic mode where a process does not have appreciable net capacity moving forward, and is removed from the myopic efficiency table. At the same time, we still want it in the existing capacity parameter for accounting purposes. This creates a conflict in the existing capacity check. So, in myopic, we make that error a warning instead.

Also fix the test sets don't know why they were broken.